### PR TITLE
faster triggering of css, follows OS dark/light theme

### DIFF
--- a/misc/theme-solarized/Makefile
+++ b/misc/theme-solarized/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		theme-solarized
-PLUGIN_VERSION=		0.2
-PLUGIN_COMMENT=		Solarized theme with dark/light switch
+PLUGIN_VERSION=		0.3
+PLUGIN_COMMENT=		Solarized theme - tracking OS dark mode
 PLUGIN_MAINTAINER=	mihak09@gmail.com
 
 .include "../../Mk/plugins.mk"

--- a/misc/theme-solarized/pkg-descr
+++ b/misc/theme-solarized/pkg-descr
@@ -1,6 +1,7 @@
 The Solarized theme allows inverting color scheme 
 from dark to bright - by injecting a theme toggle
-in the top right corner.
+in the top right corner. It defaults to the default
+preference of the OS (Mac or Windows)
 
 Colors and the dark/light flipping concept taken
 from https://ethanschoonover.com/solarized/

--- a/misc/theme-solarized/src/opnsense/www/themes/solarized/build/css/colors.css
+++ b/misc/theme-solarized/src/opnsense/www/themes/solarized/build/css/colors.css
@@ -1,43 +1,22 @@
 @charset "UTF-8";
-  
 :root {
---base03:    #002b36;
---base02:    #073642;
---base01:    #586e75;
---base00:    #657b83;
---base0:     #839496;
---base1:     #93a1a1;
---base2:     #eee8d5;
---base3:     #fdf6e3;
+--base3: #fdf6e3;
+--base2: #eee8d5;
+--base1: #93a1a1;
+--base0: #839496;
+--base00:#657b83;
+--base01:#586e75;
+--base02:#073642;
+--base03:#002b36;
 
---yellow:   #b58900;
---orange:   #e55800;
---red:      #dc322f;
---magenta:  #d33682;
---violet:   #6c71c4;
---blue:     #278bd3;
---cyan:     #2aa198;
---green:    #859900;
+--accent:#e55800;
 
---accent:  var(--orange);
-
---b03:    var(--base03);
---b02:    var(--base02);
---b01:    var(--base01);
---b00:    var(--base00);
---b0:     var(--base0);
---b1:     var(--base1);
---b2:     var(--base2);
---b3:     var(--base3);
-  }
-
-[data-theme="dark"] {
---b03:    var(--base3);
---b02:    var(--base2);
---b01:    var(--base1);
---b00:    var(--base0);
---b0:     var(--base00);
---b1:     var(--base01);
---b2:     var(--base02);
---b3:     var(--base03);
-}  
+--yellow: #b58900;
+--orange: #e55800;
+--red:    #dc322f;
+--magenta:#d33682;
+--violet: #6c71c4;
+--blue:   #278bd3;
+--cyan:   #2aa198;
+--green:  #859900;
+}

--- a/misc/theme-solarized/src/opnsense/www/themes/solarized/build/css/dark.css
+++ b/misc/theme-solarized/src/opnsense/www/themes/solarized/build/css/dark.css
@@ -1,0 +1,35 @@
+@charset "UTF-8";
+:root {
+  --b3:var(--base03);
+  --b2:var(--base02);
+  --b1:var(--base01);
+  --b0:var(--base00);
+  --b00:var(--base0);
+  --b01:var(--base1);
+  --b02:var(--base2);
+  --b03:var(--base3);
+}
+
+
+[data-theme="dark"] {
+  --b3:var(--base03);
+  --b2:var(--base02);
+  --b1:var(--base01);
+  --b0:var(--base00);
+  --b00:var(--base0);
+  --b01:var(--base1);
+  --b02:var(--base2);
+  --b03:var(--base3);
+  }
+  
+  [data-theme="light"] {
+  --b3:var(--base3);
+  --b2:var(--base2);
+  --b1:var(--base1);
+  --b0:var(--base0);
+  --b00:var(--base00);
+  --b01:var(--base01);
+  --b02:var(--base02);
+  --b03:var(--base03);
+  };
+  

--- a/misc/theme-solarized/src/opnsense/www/themes/solarized/build/css/light.css
+++ b/misc/theme-solarized/src/opnsense/www/themes/solarized/build/css/light.css
@@ -1,0 +1,35 @@
+@charset "UTF-8";
+:root {
+  --b3:var(--base3);
+  --b2:var(--base2);
+  --b1:var(--base1);
+  --b0:var(--base0);
+  --b00:var(--base00);
+  --b01:var(--base01);
+  --b02:var(--base02);
+  --b03:var(--base03);
+}
+
+
+[data-theme="dark"] {
+  --b3:var(--base03);
+  --b2:var(--base02);
+  --b1:var(--base01);
+  --b0:var(--base00);
+  --b00:var(--base0);
+  --b01:var(--base1);
+  --b02:var(--base2);
+  --b03:var(--base3);
+  }
+  
+  [data-theme="light"] {
+  --b3:var(--base3);
+  --b2:var(--base2);
+  --b1:var(--base1);
+  --b0:var(--base0);
+  --b00:var(--base00);
+  --b01:var(--base01);
+  --b02:var(--base02);
+  --b03:var(--base03);
+  };
+  

--- a/misc/theme-solarized/src/opnsense/www/themes/solarized/build/css/main.css
+++ b/misc/theme-solarized/src/opnsense/www/themes/solarized/build/css/main.css
@@ -1,5 +1,7 @@
 @charset "UTF-8";
 @import "colors.css";
+@import "dark.css" screen and (prefers-color-scheme: dark);
+@import "light.css" screen and (prefers-color-scheme: no-preference), (prefers-color-scheme: light);
 
 
 .widgetdiv .content-box-head {

--- a/misc/theme-solarized/src/opnsense/www/themes/solarized/build/js/theme.js
+++ b/misc/theme-solarized/src/opnsense/www/themes/solarized/build/js/theme.js
@@ -1,18 +1,24 @@
-$( document ).ready(function() {
+document.addEventListener('readystatechange', (event) => {
+    //const theme = localStorage.getItem('theme') ? localStorage.getItem('theme') : 'light';
+	document.documentElement.setAttribute('data-theme', getTheme());
+});
+
+$(document).ready(function() {
 	$('ul.nav.navbar-nav.navbar-right').append("<li><span class=\"navbar-theme\" id=\"theme_toggle\"><label class=\"theme-switch\" for=\"checkbox\"><input type=\"checkbox\" id=\"checkbox\" /><div class=\"slider round\"></div></label></span>")
 
-const toggleSwitch = document.querySelector('.theme-switch input[type="checkbox"]');
-toggleSwitch.addEventListener('input', switchTheme);
-const currentTheme = localStorage.getItem('theme') ? localStorage.getItem('theme') : null;
-if (currentTheme) {
-	document.documentElement.setAttribute('data-theme', currentTheme);
-	if (currentTheme === 'dark') {
-		toggleSwitch.checked = true;
-	}
-}
+	const toggleSwitch = document.querySelector('.theme-switch input[type="checkbox"]');
+	toggleSwitch.addEventListener('input', switchTheme);
 
-$('#debug').text("storage: "+currentTheme);
+	if (getTheme() === 'dark') {toggleSwitch.checked = true;}
 });
+
+function getTheme() {
+	var theme = 'light';
+	if (localStorage.getItem('theme')) {
+		if (localStorage.getItem('theme') === 'dark') {theme = 'dark';}
+	} else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {theme = 'dark';}
+	return theme;
+}
 
 function switchTheme(e) {
 	if (e.target.checked) {
@@ -24,9 +30,3 @@ function switchTheme(e) {
 		localStorage.setItem('theme', 'light');
 	}
   };
-
-
-  /*
-              <li><span class="navbar-text" id="theme_toggle"><label class="theme-switch" for="checkbox"><input type="checkbox" id="checkbox" /></label></span>
-            </li>
-  */


### PR DESCRIPTION
Two improvements:
1. default theme follows the one set by OS - (`prefers-coloor-scheme`)
     (this should prevent flickering as long as Solarized dark/light theme is the same as OS dark/light theme)
2. faster event trigger within theme.js - switched to `document.readystatechange`, the first possible event during page load
    (this should minimize - but not eliminate - the flicker if OS theme and Solarized theme are different)

The core grudge that I have is with files `usr/local/www/head.inc` and  `usr/local/opnsense/mvc/app/views/layouts/default.volt` 
They both include theme.js so late - literally at the end of everything. This is really not theming-friendly.

Let me know if these two fixes are bearable.