### PR TITLE
NextDNS: enable system logging of nextdns daemon

### DIFF
--- a/dns/nextdns-community/src/etc/rc.d/nextdns
+++ b/dns/nextdns-community/src/etc/rc.d/nextdns
@@ -8,7 +8,7 @@ rcvar=nextdns_enable
 pidfile=/var/run/${name}.pid
 
 command=/usr/sbin/daemon
-command_args="-f -P ${pidfile} ${name} run &"
+command_args="-P ${pidfile} ${name} run &"
 
 stop_cmd="killall nextdns"
 status_cmd=nextdns_status

--- a/dns/nextdns-community/src/opnsense/mvc/app/controllers/OPNsense/Nextdns/forms/general.xml
+++ b/dns/nextdns-community/src/opnsense/mvc/app/controllers/OPNsense/Nextdns/forms/general.xml
@@ -91,10 +91,10 @@
     
     <field>
         <id>general.logqueries</id>
-        <label>Log queries</label>
+        <label>Log queries to local log</label>
         <type>checkbox</type>
         <advanced>true</advanced>
-        <help>Log DNS queries</help>
+        <help>Add DNS queries to OPNsense local log. Disabling this option will not disable general system logging of NextDNS.</help>
     </field>
     
     <field>

--- a/dns/nextdns-community/src/opnsense/mvc/app/models/OPNsense/Nextdns/General.xml
+++ b/dns/nextdns-community/src/opnsense/mvc/app/models/OPNsense/Nextdns/General.xml
@@ -60,7 +60,7 @@
         </timeout>
 
         <logqueries type="BooleanField">
-            <default>1</default>
+            <default>0</default>
             <Required>N</Required>            
         </logqueries>
 


### PR DESCRIPTION
- removing -f from daemon starting arguments (-f  redirects standard input, standard output and standard error to /dev/null)
- changing default local logging of DNS queries to False (no need to do local logging deluge if all is logged at my.nextdns.com already)
- Improving help to explain log-queries option (system log is intact regardless if this feature is true or false)