### PR TITLE
Update for Ookla/speedtest-cli module changes

### DIFF
--- a/net-mgmt/speedtest-community/src/opnsense/scripts/OPNsense/speedtest/install_speedtest.sh
+++ b/net-mgmt/speedtest-community/src/opnsense/scripts/OPNsense/speedtest/install_speedtest.sh
@@ -24,14 +24,14 @@
 if [ $1 = 'http' ] 
 then 
   pkg delete -y speedtest
-  pkg install -f -y py37-speedtest-cli
+  pkg install -f -y py38-speedtest-cli
 elif [ $1 = 'socket' ] 
 then 
-  pkg delete -y py37-speedtest-cli
+  pkg delete -y py37-speedtest-cli py38-speedtest-cli
   pkg install -y libidn2
-  pkg add -f "https://bintray.com/ookla/download/download_file?file_path=ookla-speedtest-1.0.0-freebsd.pkg"
+  pkg add -f "https://install.speedtest.net/app/cli/ookla-speedtest-1.0.0-freebsd.pkg"
 elif [ $1 = 'delete' ]
 then
   pkg delete -y speedtest
-  pkg delete -y py37-speedtest-cli
+  pkg delete -y py37-speedtest-cli py38-speedtest-cli
 fi


### PR DESCRIPTION
Suggested changes to address #67. The changes regarding speedtest-cli assume the system is using Python 3.8 (ie OPNsense 21.7 or later), and that it may have an older Python 3.7 speedtest-cli module installed if the plugin was used before OPNsense 21.7. There is probably a more robust way to implement this (for example, test which Python version is being used)?