### PR TITLE
Add ACL file for Speedtest

### DIFF
--- a/net-mgmt/speedtest-community/src/opnsense/mvc/app/models/OPNsense/Speedtest/ACL/ACL.xml
+++ b/net-mgmt/speedtest-community/src/opnsense/mvc/app/models/OPNsense/Speedtest/ACL/ACL.xml
@@ -1,0 +1,8 @@
+<acl>
+    <page-reporting-speedtest>
+        <name>Monitoring: Speedtest</name>
+        <patterns>
+            <pattern>api/speedtest/service/*</pattern>
+        </patterns>
+    </page-reporting-speedtest>
+</acl>


### PR DESCRIPTION
Add ACL file for Speedtest so it can be used in the user privileges to only allow access to the `/api/speedtest/service/*` endpoints instead of the need to give the user access to all endpoints.