### PR TITLE
Added most-recent speedtest result and new 24.7 widget

### DIFF
--- a/net-mgmt/speedtest-community/src/opnsense/mvc/app/controllers/OPNsense/Speedtest/Api/ServiceController.php
+++ b/net-mgmt/speedtest-community/src/opnsense/mvc/app/controllers/OPNsense/Speedtest/Api/ServiceController.php
@@ -56,6 +56,11 @@ class ServiceController extends ApiControllerBase
     {
         return (new Backend())->configdRun("speedtest showlog");
     }
+	
+	public function showrecentAction()
+	{
+		return (new Backend())->configdRun("speedtest showrecent");
+	}
 
     public function deletelogAction()
     {

--- a/net-mgmt/speedtest-community/src/opnsense/scripts/OPNsense/speedtest/opn_speedtest.py
+++ b/net-mgmt/speedtest-community/src/opnsense/scripts/OPNsense/speedtest/opn_speedtest.py
@@ -79,6 +79,28 @@ try:
         print(json.dumps(array[:50]))
         quit()
 
+    # parameter r or recent - returning the last 1 entries from csv
+    if arg=='r' or arg == 'recent':
+        f = open(csvfile, 'r', encoding="utf-8")
+        data = csv.reader(f,dialect='excel')
+        header = next(data)
+        row=[]
+        for row in data:
+            #from timestamp to visual form
+            row[0]=datetime.fromtimestamp(float(row[0])).isoformat()
+        f.close()
+        out = {
+            'date': str(row[0]),
+            'server': row[2] + " " + row[3],
+            'download': row[5],
+            'upload': row[6],
+            'latency': row[7],
+            'url': row[8]
+        }
+        print(json.dumps(out))
+        quit()
+
+
     # parameter s or stat - return statistics
     if arg=='s' or arg=='stat':
         latencyarray = []

--- a/net-mgmt/speedtest-community/src/opnsense/service/conf/actions.d/actions_speedtest.conf
+++ b/net-mgmt/speedtest-community/src/opnsense/service/conf/actions.d/actions_speedtest.conf
@@ -29,6 +29,12 @@ parameters:
 type:script_output
 message: Shows speedtest log (last 50 entries)
 
+[showrecent]
+command:/usr/local/bin/python3 /usr/local/opnsense/scripts/OPNsense/speedtest/opn_speedtest.py recent
+parameters: 
+type:script_output
+message: Shows speedtest most recent log entry
+
 [deletelog]
 command:/bin/rm /usr/local/opnsense/scripts/OPNsense/speedtest/speedtest.csv
 parameters: 

--- a/net-mgmt/speedtest-community/src/opnsense/www/js/widgets/Metadata/Speedtest.xml
+++ b/net-mgmt/speedtest-community/src/opnsense/www/js/widgets/Metadata/Speedtest.xml
@@ -1,0 +1,16 @@
+<metadata>
+    <speedtest>
+        <filename>Speedtest.js</filename>
+        <endpoints>
+            <endpoint>/api/speedtest/service/showrecent</endpoint>
+            <endpoint>/api/speedtest/service/showstat</endpoint>
+        </endpoints>
+        <translations>
+            <title>Speedtest</title>
+            <most_recent>Most Recent</most_recent>
+            <avg_latency>Avg. Latency</avg_latency>
+            <avg_download>Avg. Download</avg_download>
+            <avg_upload>Avg. Upload</avg_upload>
+        </translations>
+    </speedtest>
+</metadata>

--- a/net-mgmt/speedtest-community/src/opnsense/www/js/widgets/Speedtest.js
+++ b/net-mgmt/speedtest-community/src/opnsense/www/js/widgets/Speedtest.js
@@ -1,0 +1,80 @@
+
+/*
+ * Copyright (C) 2024 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+/*
+ * Copyright (C) 2024 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import BaseTableWidget from "./BaseTableWidget.js";
+
+export default class ETProTelemetry extends BaseTableWidget {
+    constructor() {
+        super();
+        this.tickTimeout = 3600;
+    }
+    getGridOptions() { 
+        return {
+        };
+    }
+    getMarkup() {
+        let $container = $('<div></div>');
+        let $Speedtesttable = this.createTable('speedtest-table', {
+            headerPosition: 'left',
+        });
+        $container.append($Speedtesttable);
+        return $container;
+    }
+
+    async onWidgetTick() {
+        const status_data = await this.ajaxCall('/api/speedtest/service/showstat');
+        const recent_data = await this.ajaxCall('/api/speedtest/service/showrecent');
+        $('#speedtest_most_recent').html(`<a href="${recent_data['url']}" target="_blank">${recent_data['date']}</a> <strong>Down: ${recent_data['download']} Mbps</strong><br/>(up: ${recent_data['upload']} Mbps, latency: ${recent_data['latency']} ms)`);
+        $('#speedtest_avg_latency').html(`<strong>${status_data['latency']['avg']} ms</strong> (min: ${status_data['latency']['min']}, max: ${status_data['latency']['max']})`);
+        $('#speedtest_avg_download').html(`<strong>${status_data['download']['avg']} Mbps</strong> (min: ${status_data['download']['min']}, max: ${status_data['download']['max']})`);
+        $('#speedtest_avg_upload').html(`<strong>${status_data['upload']['avg']} Mbps</strong> (min: ${status_data['upload']['min']}, max: ${status_data['upload']['max']})`);
+ }
+
+    async onMarkupRendered() {
+        let rows = [];
+        rows.push([[this.translations['most_recent']], $('<span id="speedtest_most_recent">').prop('outerHTML')]);
+        rows.push([[this.translations['avg_latency']], $('<span id="speedtest_avg_latency">').prop('outerHTML')]);
+        rows.push([[this.translations['avg_download']], $('<span id="speedtest_avg_download">').prop('outerHTML')]);
+        rows.push([[this.translations['avg_upload']], $('<span id="speedtest_avg_upload">').prop('outerHTML')]);
+
+        super.updateTable('speedtest-table', rows);
+    }
+}
+

--- a/net-mgmt/speedtest-community/src/opnsense/www/js/widgets/Speedtest.js
+++ b/net-mgmt/speedtest-community/src/opnsense/www/js/widgets/Speedtest.js
@@ -68,6 +68,7 @@ export default class ETProTelemetry extends BaseTableWidget {
  }
 
     async onMarkupRendered() {
+        $(`#${this.id}-title`).html(`<b><a href="/ui/speedtest/">${this.translations['title']}</a></b>`);
         let rows = [];
         rows.push([[this.translations['most_recent']], $('<span id="speedtest_most_recent">').prop('outerHTML')]);
         rows.push([[this.translations['avg_latency']], $('<span id="speedtest_avg_latency">').prop('outerHTML')]);

--- a/net-mgmt/speedtest-community/src/opnsense/www/js/widgets/Speedtest.js
+++ b/net-mgmt/speedtest-community/src/opnsense/www/js/widgets/Speedtest.js
@@ -38,9 +38,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import BaseTableWidget from "./BaseTableWidget.js";
-
-export default class ETProTelemetry extends BaseTableWidget {
+export default class Speedtest extends BaseTableWidget {
     constructor() {
         super();
         this.tickTimeout = 3600;

--- a/net-mgmt/speedtest-community/src/www/widgets/widgets/speedtest.widget.php
+++ b/net-mgmt/speedtest-community/src/www/widgets/widgets/speedtest.widget.php
@@ -28,17 +28,21 @@ require_once("guiconfig.inc");
 ?>
 <script>
     $(document).ready(function() {
+        ajaxGet("/api/speedtest/service/showrecent", {}, function(l,status) {
+			$('#stat_recent').html("<a href='" + l.url + "' target='_blank'>"+l.date+"</a> <b>Down: "+l.download+" Mbps<\/b><small> (up: "+l.upload+" Mbps, latency: "+l.latency +" ms)</small>");
+		});
         ajaxGet("/api/speedtest/service/showstat", {}, function(l,status) {
-            $('#stat_samples').html("<b>"+l.samples+"<\/b>")
-            $('#stat_latency').html("<b>"+l.latency.avg+" ms<\/b><small> (min: "+l.latency.min+" ms, max: "+l.latency.max +" ms)</small>")
-            $('#stat_download').html("<b>"+l.download.avg+" Mbps<\/b><small> (min: "+l.download.min+" Mbps, max: "+l.download.max +" Mbps)</small>")
-            $('#stat_upload').html("<b>"+l.upload.avg+" Mbps<\/b><small> (min: "+l.upload.min+" Mbps, max: "+l.upload.max +" Mbps)</small>")
+            $('#stat_samples').html("<b>"+l.samples+"<\/b>");
+            $('#stat_latency').html("<b>"+l.latency.avg+" ms<\/b><small> (min: "+l.latency.min+" ms, max: "+l.latency.max +" ms)</small>");
+            $('#stat_download').html("<b>"+l.download.avg+" Mbps<\/b><small> (min: "+l.download.min+" Mbps, max: "+l.download.max +" Mbps)</small>");
+            $('#stat_upload').html("<b>"+l.upload.avg+" Mbps<\/b><small> (min: "+l.upload.min+" Mbps, max: "+l.upload.max +" Mbps)</small>");
         });
     });
 </script>
 <!-- gateway table -->
 <table id="speedtest_widget_table" class="table table-striped table-condensed">
-  <tr><td style="width:25%">Avg Latency:</td><td><div id="stat_latency">0.00 ms (min: 0.00 ms, max: 0.00 ms)</div></td></tr>
+  <tr><td style="width:25%">Most Recent:</td><td><div id="stat_recent">0 Mbps (upload: 0 Mbps)</div></td></tr>
+  <tr><td>Avg Latency:</td><td><div id="stat_latency">0.00 ms (min: 0.00 ms, max: 0.00 ms)</div></td></tr>
   <tr><td>Avg Download:</td><td><div id="stat_download">0 Mbps (min: 0 Mbps, max: 0 Mbps)</div></td></tr>
   <tr><td>Avg Upload:</td><td><div id="stat_upload">0 Mbps (min: 0 Mbps, max: 0 Mbps)</div></td></tr>
 </table>


### PR DESCRIPTION
OPNSense 24.7 has a new widget format, which is provided here. There is also a new "most-recent" result displayed in the widget. The most-recent result lets you see what most-recently happened without having to navigate to the Reporting>Speedtest page and then expanding the "show log" section.