### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/net-mgmt/speedtest-community/src/opnsense/scripts/OPNsense/speedtest/opn_speedtest.py
+++ b/net-mgmt/speedtest-community/src/opnsense/scripts/OPNsense/speedtest/opn_speedtest.py
@@ -180,7 +180,7 @@ try:
             cmd = [speedtest, '--list']
             serverlist = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True).stdout.decode('utf-8').splitlines()
             for line in serverlist[1:11]:
-                rec = re.split("\) | \(|, ", line)
+                rec = re.split(r"\) | \(|, ", line)
                 out = {'id':rec[0].strip(), "name":rec[1].strip(), "location":rec[2].strip()+", "+rec[3], "country":rec[4].strip()}
                 array.append(out)
         print(json.dumps(array))


### PR DESCRIPTION
Fix Error on opnsense:

```
Script action stderr returned "b'/usr/local/opnsense/scripts/OPNsense/speedtest/opn_speedtest.py:183: SyntaxWarning: invalid escape sequence \'\\)\'\n rec = re.split("\\) | \\(|, ", line)'"
```
on last opnsense versions.

See also ==> https://github.com/mihakralj/opnsense-speedtest/issues/19